### PR TITLE
Correctly Use Network System Account

### DIFF
--- a/nsis/jellyfin.nsi
+++ b/nsis/jellyfin.nsi
@@ -246,7 +246,7 @@ ${If} $_INSTALLSERVICE_ == "Yes" ; Only run this if we're going to install the s
     Sleep 3000
     ${If} $_SERVICEACCOUNTTYPE_ == "NetworkService" ; the default install using NSSM is Local System
         ConfigureNetworkServiceRetry:
-        ExecWait '"$INSTDIR\nssm.exe" set JellyfinServer Objectname "Network Service"' $0
+        ExecWait '"$INSTDIR\nssm.exe" set JellyfinServer Objectname "NT Authority\NetworkService"' $0
         ${If} $0 <> 0
             !insertmacro ShowError "Could not configure the Jellyfin Server service account." ConfigureNetworkServiceRetry
         ${EndIf}


### PR DESCRIPTION
According to the NSSM readme (mirrored at [kirillkovalenko/nssm](https://github.com/kirillkovalenko/nssm), in [cca8d28](https://github.com/kirillkovalenko/nssm/commit/cca8d28295ce27b7c996b47badc6a1e3a6a34e65) a function was added to specify special account names.

Looking further at the code, this will look up the correct SID for us, avoiding any non-English Windows issues.

Fixes https://github.com/jellyfin/jellyfin/issues/2119.