### PR TITLE
Remove --noautorunwebapp argument

### DIFF
--- a/Jellyfin.Windows.Tray/TrayApplicationContext.cs
+++ b/Jellyfin.Windows.Tray/TrayApplicationContext.cs
@@ -185,7 +185,7 @@ namespace Jellyfin.Windows.Tray
                 Process p = new Process();
                 p.StartInfo.FileName = _executableFile;
                 p.StartInfo.CreateNoWindow = true;
-                p.StartInfo.Arguments = "--noautorunwebapp --datadir \"" + _dataFolder + "\"";
+                p.StartInfo.Arguments = "--datadir \"" + _dataFolder + "\"";
                 p.Start();
             }
         }


### PR DESCRIPTION
Fixes #43

I tested running jellyfin with and without this argument and it worked without, did not test it with the tray app though. I'm also not sure what the current state of the release process of this project it since all builds have been failing for months.