### PR TITLE
Close the tray app before uninstall

### DIFF
--- a/nsis/jellyfin.nsi
+++ b/nsis/jellyfin.nsi
@@ -315,6 +315,7 @@ Section "Uninstall"
 
     PreserveData:
 
+    ExecWait "TaskKill /IM Jellyfin.Windows.Tray.exe /F"
     ExecWait '"$INSTDIR\nssm.exe" statuscode JellyfinServer' $0
     DetailPrint "Jellyfin Server service statuscode, $0"
     IntCmp $0 0 NoServiceUninstall ; service doesn't exist, may be run from desktop shortcut


### PR DESCRIPTION
Adds a line to kill the tray app before proceeding with the uninstall. The uninstaller is also part of the upgrade process, so this takes care of both scenarios.

Fixes #38.