### PR TITLE
Move port check to network.xml

### DIFF
--- a/Jellyfin.Windows.Tray/TrayApplicationContext.cs
+++ b/Jellyfin.Windows.Tray/TrayApplicationContext.cs
@@ -171,6 +171,7 @@ public class TrayApplicationContext : ApplicationContext
             if (_requireHTTPS)
             {
                 _uriScheme = "https://";
+                _networkAddress = networkReader.SelectSingleNode("/NetworkConfiguration/BaseUrl").Value;
                 _port = settingsReader.SelectSingleNode("/NetworkConfiguration/HttpsPortNumber")?.Value;
             }
 

--- a/Jellyfin.Windows.Tray/TrayApplicationContext.cs
+++ b/Jellyfin.Windows.Tray/TrayApplicationContext.cs
@@ -154,7 +154,6 @@ public class TrayApplicationContext : ApplicationContext
             XPathNavigator settingsReader = systemXml.CreateNavigator();
 
             _firstRunDone = settingsReader.SelectSingleNode("/ServerConfiguration/IsStartupWizardCompleted").ValueAsBoolean;
-
         }
 
         if (File.Exists(_networkFile))

--- a/Jellyfin.Windows.Tray/TrayApplicationContext.cs
+++ b/Jellyfin.Windows.Tray/TrayApplicationContext.cs
@@ -164,7 +164,6 @@ public class TrayApplicationContext : ApplicationContext
 
             _networkAddress = networkReader.SelectSingleNode("/NetworkConfiguration/LocalNetworkAddresses").Value;
             _port = networkReader.SelectSingleNode("/NetworkConfiguration/PublicPort")?.Value;
-
         }
 
         if (string.IsNullOrEmpty(_port))

--- a/Jellyfin.Windows.Tray/TrayApplicationContext.cs
+++ b/Jellyfin.Windows.Tray/TrayApplicationContext.cs
@@ -26,8 +26,6 @@ public class TrayApplicationContext : ApplicationContext
     private string _networkFile;
     private string _port;
     private bool _firstRunDone = false;
-    private string _uriScheme = "http://";
-    private bool _requireHTTPS = false;
     private string _networkAddress;
     private string _executableFile;
     private string _dataFolder = @"C:\ProgramData\Jellyfin\Server";
@@ -164,16 +162,8 @@ public class TrayApplicationContext : ApplicationContext
             XDocument networkXml = XDocument.Load(_networkFile);
             XPathNavigator networkReader = networkXml.CreateNavigator();
 
-            _requireHTTPS = settingsReader.SelectSingleNode("/NetworkConfiguration/RequireHttps").ValueAsBoolean;
             _networkAddress = networkReader.SelectSingleNode("/NetworkConfiguration/LocalNetworkAddresses").Value;
             _port = networkReader.SelectSingleNode("/NetworkConfiguration/PublicPort")?.Value;
-
-            if (_requireHTTPS)
-            {
-                _uriScheme = "https://";
-                _networkAddress = networkReader.SelectSingleNode("/NetworkConfiguration/BaseUrl").Value;
-                _port = networkReader.SelectSingleNode("/NetworkConfiguration/HttpsPortNumber")?.Value;
-            }
 
         }
 
@@ -187,7 +177,7 @@ public class TrayApplicationContext : ApplicationContext
             _networkAddress = "localhost";
         }
 
-        _localJellyfinUrl = _uriScheme + _networkAddress + ":" + _port + "/web/index.html";
+        _localJellyfinUrl = "http://" + _networkAddress + ":" + _port + "/web/index.html";
     }
 
     private bool CheckShowServiceNotElevatedWarning()

--- a/Jellyfin.Windows.Tray/TrayApplicationContext.cs
+++ b/Jellyfin.Windows.Tray/TrayApplicationContext.cs
@@ -166,13 +166,13 @@ public class TrayApplicationContext : ApplicationContext
 
             _requireHTTPS = settingsReader.SelectSingleNode("/NetworkConfiguration/RequireHttps").ValueAsBoolean;
             _networkAddress = networkReader.SelectSingleNode("/NetworkConfiguration/LocalNetworkAddresses").Value;
-            _port = settingsReader.SelectSingleNode("/NetworkConfiguration/PublicPort")?.Value;
+            _port = networkReader.SelectSingleNode("/NetworkConfiguration/PublicPort")?.Value;
 
             if (_requireHTTPS)
             {
                 _uriScheme = "https://";
                 _networkAddress = networkReader.SelectSingleNode("/NetworkConfiguration/BaseUrl").Value;
-                _port = settingsReader.SelectSingleNode("/NetworkConfiguration/HttpsPortNumber")?.Value;
+                _port = networkReader.SelectSingleNode("/NetworkConfiguration/HttpsPortNumber")?.Value;
             }
 
         }


### PR DESCRIPTION
Moves the port check to the network XML file~~, and also checks for HTTPS if needed~~.

~~If Enable HTTPS is true, then it also gets the baseURL, if configured. I assume people would have a desired hostname for their certificate at this point.~~

Removed the HTTPS check for now, until it can be done correctly.

Fixes #63.