### PR TITLE
Read the correct value for local HTTP port

### DIFF
--- a/Jellyfin.Windows.Tray/TrayApplicationContext.cs
+++ b/Jellyfin.Windows.Tray/TrayApplicationContext.cs
@@ -162,7 +162,7 @@ public class TrayApplicationContext : ApplicationContext
             XPathNavigator networkReader = networkXml.CreateNavigator();
 
             _networkAddress = networkReader.SelectSingleNode("/NetworkConfiguration/LocalNetworkAddresses").Value;
-            _port = networkReader.SelectSingleNode("/NetworkConfiguration/PublicPort")?.Value;
+            _port = networkReader.SelectSingleNode("/NetworkConfiguration/HttpServerPortNumber")?.Value;
         }
 
         if (string.IsNullOrEmpty(_port))


### PR DESCRIPTION
When reading the network.xml config, we were pulling `PublicPort`, which is the _external_ port used for remote connections by the network manager. Since the tray utility will only ever run on the actual server, we only need the `HttpServerPortNumber`, which is the local HTTP port.

Fixes #71.