### PR TITLE
Extending logging and observing of Startup status and fixing application exit on config error

### DIFF
--- a/Jellyfin.Windows.Tray/Program.cs
+++ b/Jellyfin.Windows.Tray/Program.cs
@@ -14,7 +14,11 @@ namespace Jellyfin.Windows.Tray
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
 
-            Application.Run(new TrayApplicationContext());
+            var trayApplicationContext = new TrayApplicationContext();
+            if (trayApplicationContext.InitApplication())
+            {
+                Application.Run(trayApplicationContext);
+            }
         }
     }
 }

--- a/Jellyfin.Windows.Tray/StringExtensions.cs
+++ b/Jellyfin.Windows.Tray/StringExtensions.cs
@@ -1,0 +1,22 @@
+#nullable enable
+namespace Jellyfin.Windows.Tray;
+
+/// <summary>
+///     Helper Methods for Strings.
+/// </summary>
+public static class StringExtensions
+{
+    /// <summary>
+    ///     Truncates the input string to a max size and appends the suffix if truncated.
+    /// </summary>
+    /// <param name="value">The input string to truncate.</param>
+    /// <param name="maxLength">The Maximum Length.</param>
+    /// <param name="truncationSuffix">The suffix to append when Truncated.</param>
+    /// <returns>The original string if not exceeding <paramref name="maxLength"/> otherwise the truncated string with <paramref name="truncationSuffix"/>.</returns>
+    public static string? Truncate(this string? value, int maxLength, string truncationSuffix = "…")
+    {
+        return value?.Length > maxLength
+            ? value.Substring(0, maxLength) + truncationSuffix
+            : value;
+    }
+}


### PR DESCRIPTION
- Fixed application not stopping on issue with Configuration at startup
Application.Exit does not work until the application is actually started. Application starts only after the constructor of `TrayApplicationContext` runs so a call inside the ctor of `TrayApplicationContext` to `Application.Exit` does nothing.
- Extended Logging when server process cannot be started
- Added short term Watchdog for process and service to observe that either did actually start after grace period