### PR TITLE
Update TargetFramework to net481

### DIFF
--- a/Jellyfin.Windows.Tray/Jellyfin.Windows.Tray.csproj
+++ b/Jellyfin.Windows.Tray/Jellyfin.Windows.Tray.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net481</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <ApplicationIcon>JellyfinIcon.ico</ApplicationIcon>


### PR DESCRIPTION
Updated the target framework to the latest .NET framework. I'm running this a build from this branch myself for my 10.9 install without any problems.