### PR TITLE
Downgrade to .NET 4.8.0

### DIFF
--- a/Jellyfin.Windows.Tray/Jellyfin.Windows.Tray.csproj
+++ b/Jellyfin.Windows.Tray/Jellyfin.Windows.Tray.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net481</TargetFramework>
+    <TargetFramework>net480</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <ApplicationIcon>JellyfinIcon.ico</ApplicationIcon>


### PR DESCRIPTION
Compatibility of .NET 4.8.0 is way better than the one of  4.8.1: https://learn.microsoft.com/en-us/dotnet/framework/migration-guide/versions-and-dependencies#net-framework-48

Fixes #119