### PR TITLE
Move tray app to .NET 4.7.2

### DIFF
--- a/.github/workflows/_meta-publish.yaml
+++ b/.github/workflows/_meta-publish.yaml
@@ -36,7 +36,9 @@ jobs:
           Copy-Item ".\nssm\nssm.exe" -Destination $(Resolve-Path .\jellyfin\jellyfin)
 
       - name: Publish Tray
-        run: dotnet publish -c Release -r win-x64 -f net472 --no-self-contained --output $(Resolve-Path .\jellyfin\jellyfin-windows-tray)
+        run: |
+          New-Item -Path .\jellyfin\jellyfin\jellyfin-windows-tray -ItemType Directory
+          dotnet publish -c Release -r win-x64 -f net472 --no-self-contained --output $(Resolve-Path .\jellyfin\jellyfin\jellyfin-windows-tray)
 
       - name: Build installer
         run: |

--- a/.github/workflows/_meta-publish.yaml
+++ b/.github/workflows/_meta-publish.yaml
@@ -28,7 +28,7 @@ jobs:
           Invoke-WebRequest '${{ inputs.server_url }}' -OutFile 'jellyfin.zip'
           Expand-Archive 'jellyfin.zip'
           Copy-Item ".\Support Files\LICENSE" -Destination $(Resolve-Path .\jellyfin\jellyfin)
-      
+
       - name: Add NSSM
         run: |
           Invoke-WebRequest 'https://repo.jellyfin.org/releases/other/nssm.zip' -OutFile 'nssm.zip'
@@ -36,7 +36,7 @@ jobs:
           Copy-Item ".\nssm\nssm.exe" -Destination $(Resolve-Path .\jellyfin\jellyfin)
 
       - name: Publish Tray
-        run: dotnet publish -c Release -r win-x64 --no-self-contained --output $(Resolve-Path .\jellyfin\jellyfin)
+        run: dotnet publish -c Release -r win-x64 -f net472 --no-self-contained --output $(Resolve-Path .\jellyfin\jellyfin-windows-tray)
 
       - name: Build installer
         run: |

--- a/Jellyfin.Windows.Tray/Jellyfin.Windows.Tray.csproj
+++ b/Jellyfin.Windows.Tray/Jellyfin.Windows.Tray.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net481</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <ApplicationIcon>JellyfinIcon.ico</ApplicationIcon>

--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ Do you want to build Jellyfin's tray app or installer for yourself? Read on!
 
 ### Steps
 1. Build using the dotnet command, or using Visual Studio/VS Code.
-    * On the command line, in the root of the cloned repository, execute this command: `dotnet build -c Release`
+    * On the command line, in the root of the cloned repository, execute this command: `dotnet build -c Release -f net472`
 2. From the resulting bin folder, collect `Jellyfin.Windows.Tray.exe` and all the DLLs within.
+3. For use with a Jellyfin install, place in its own directory, such as `jellyfin-windows-tray`.
 
 ### Usage
 The tray app is designed to do three things:

--- a/nsis/jellyfin.nsi
+++ b/nsis/jellyfin.nsi
@@ -277,9 +277,9 @@ Section "Create Shortcuts" CreateWinShortcuts
     ${If} $_MAKESHORTCUTS_ == "Yes"
         CreateDirectory "$SMPROGRAMS\Jellyfin Server"
         CreateShortCut "$SMPROGRAMS\Jellyfin Server\Jellyfin (View Console).lnk" "$INSTDIR\jellyfin.exe" "--datadir $\"$_JELLYFINDATADIR_$\"" "$INSTDIR\icon.ico" 0 SW_SHOWMAXIMIZED
-        CreateShortCut "$SMPROGRAMS\Jellyfin Server\Jellyfin Tray App.lnk" "$INSTDIR\Jellyfin.Windows.Tray.exe" "" "$INSTDIR\icon.ico" 0
+        CreateShortCut "$SMPROGRAMS\Jellyfin Server\Jellyfin Tray App.lnk" "$INSTDIR\jellyfin-windows-tray\Jellyfin.Windows.Tray.exe" "" "$INSTDIR\icon.ico" 0
         ;CreateShortCut "$DESKTOP\Jellyfin Server.lnk" "$INSTDIR\jellyfin.exe" "--datadir $\"$_JELLYFINDATADIR_$\"" "$INSTDIR\icon.ico" 0 SW_SHOWMINIMIZED
-        CreateShortCut "$DESKTOP\Jellyfin Server.lnk" "$INSTDIR\Jellyfin.Windows.Tray.exe" "" "$INSTDIR\icon.ico" 0
+        CreateShortCut "$DESKTOP\Jellyfin Server.lnk" "$INSTDIR\jellyfin-windows-tray\Jellyfin.Windows.Tray.exe" "" "$INSTDIR\icon.ico" 0
     ${EndIf}
 SectionEnd
 


### PR DESCRIPTION
This adds x64 Server 2019 support, for those who had issues.

We'll revisit a hybrid approach when we start building installer and tray for ARM.

Fixes #125 #119