### PR TITLE
Add Port and Running Check fixes

### DIFF
--- a/Jellyfin.Windows.Tray/TrayApplicationContext.cs
+++ b/Jellyfin.Windows.Tray/TrayApplicationContext.cs
@@ -172,7 +172,7 @@ public class TrayApplicationContext : ApplicationContext
             XPathNavigator networkReader = networkXml.CreateNavigator();
 
             _networkAddress = networkReader.SelectSingleNode("/NetworkConfiguration/LocalNetworkAddresses").Value;
-            _port = networkReader.SelectSingleNode("/NetworkConfiguration/HttpServerPortNumber")?.Value;
+            _port = networkReader.SelectSingleNode("/NetworkConfiguration/InternalHTTPPort")?.Value;
             _baseUrl = networkReader.SelectSingleNode("/NetworkConfiguration/BaseUrl")?.Value;
         }
 

--- a/nsis/jellyfin.nsi
+++ b/nsis/jellyfin.nsi
@@ -383,16 +383,6 @@ Function .onInit
     StrCmp $R0 0 +3
     !insertmacro ShowErrorFinal "The installer is already running."
 
-
-    ; This stops the installer from starting if jellyfin.exe is open
-    StrCpy $1 "jellyfin.exe"
-    nsProcess::_FindProcess "$1"
-    Pop $R1
-    ${If} $R1 = 0
-       !insertmacro ShowErrorFinal "Jellyfin is running. Please close it first."
-        Abort
-    ${EndIf}
-
 ;Detect if Jellyfin is already installed.
 ; In case it is installed, let the user choose either
 ;	1. Exit installer
@@ -434,6 +424,15 @@ Function .onInit
     SectionSetText ${CreateWinShortcuts} ""
 
     NoService: ; existing install was present but no service was detected
+        ; This stops the installer from starting if jellyfin.exe is open
+        StrCpy $1 "jellyfin.exe"
+        nsProcess::_FindProcess "$1"
+        Pop $R1
+        ${If} $R1 = 0
+        !insertmacro ShowErrorFinal "Jellyfin is running. Please close it first."
+            Abort
+        ${EndIf}
+
         ${If} $_SERVICEACCOUNTTYPE_ == "None"
             StrCpy $_SETUPTYPE_ "Basic"
             StrCpy $_INSTALLSERVICE_ "No"


### PR DESCRIPTION
Corrects the open function of the tray app to use the new name for local HTTP port from network.xml when opening the browser.

Moves the "Jellyfin is running" check to inside the basic mode upgrade prep, as it would:
1. Only be running if Jellyfin is actually installed
2. We automatically stop the service anyway, so only basic mode needs a reminder

Fixes #126
Fixes #123
Maybe #118