### PR TITLE
Use correct Http node name

### DIFF
--- a/Jellyfin.Windows.Tray/TrayApplicationContext.cs
+++ b/Jellyfin.Windows.Tray/TrayApplicationContext.cs
@@ -172,7 +172,7 @@ public class TrayApplicationContext : ApplicationContext
             XPathNavigator networkReader = networkXml.CreateNavigator();
 
             _networkAddress = networkReader.SelectSingleNode("/NetworkConfiguration/LocalNetworkAddresses").Value;
-            _port = networkReader.SelectSingleNode("/NetworkConfiguration/InternalHTTPPort")?.Value;
+            _port = networkReader.SelectSingleNode("/NetworkConfiguration/InternalHttpPort")?.Value;
             _baseUrl = networkReader.SelectSingleNode("/NetworkConfiguration/BaseUrl")?.Value;
         }
 


### PR DESCRIPTION
Use the correct node name for the port, as autocorrect had capitalized it when I was working on it.

Fixes #131
Fixes #126